### PR TITLE
fix for list_servers() returning an empty list

### DIFF
--- a/python_aternos/atclient.py
+++ b/python_aternos/atclient.py
@@ -193,7 +193,7 @@ class Client:
         serverstree = lxml.html.fromstring(serverspage.content)
 
         servers = serverstree.xpath(
-            '//div[contains(@class,"servers ")]/div'
+            '/html/body/div[1]/main/div[3]/section/div[1]/div[2]/div'
             '/div[@class="server-body"]/@data-id'
         )
         self.refresh_servers(servers)


### PR DESCRIPTION
Every account I tested which had more than 1 account returned an empty list.
This seems to fix the issue